### PR TITLE
Add a template for new services

### DIFF
--- a/.service-template/.gitignore
+++ b/.service-template/.gitignore
@@ -1,0 +1,149 @@
+
+# Created by https://www.gitignore.io/api/gradle,kotlin,intellij+all,macos
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+### Kotlin ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Gradle ###
+.gradle
+build
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties
+
+
+# End of https://www.gitignore.io/api/gradle,kotlin,intellij+all,macos

--- a/.service-template/CODEOWNERS
+++ b/.service-template/CODEOWNERS
@@ -1,0 +1,1 @@
+* @navikt/dagpenger

--- a/.service-template/Dockerfile
+++ b/.service-template/Dockerfile
@@ -1,0 +1,8 @@
+FROM navikt/java:10
+ARG APP_NAME
+ARG DIST_TAR
+ADD ${DIST_TAR}.tar /app
+RUN mkdir /app/bin \
+  && mv /app/${DIST_TAR}/bin/${APP_NAME} /app/bin/app \
+  && mv /app/${DIST_TAR}/lib /app/lib \
+  && rm -rf /app/${DIST_TAR}

--- a/.service-template/Jenkinsfile
+++ b/.service-template/Jenkinsfile
@@ -1,0 +1,87 @@
+pipeline {
+  agent any
+
+  environment {
+    APPLICATION_NAME = 'dagpenger-joark-mottak'
+    ZONE = 'fss'
+    NAMESPACE = 'default'
+    VERSION = sh(script: './gradlew -q printVersion', returnStdout: true).trim()
+  }
+
+  stages {
+    stage('Install dependencies') {
+      steps {
+        sh "./gradlew assemble"
+      }
+    }
+
+    stage('Build') {
+      steps {
+        sh "./gradlew check"
+      }
+
+      post {
+        always {
+          publishHTML target: [
+            allowMissing: true,
+            alwaysLinkToLastBuild: false,
+            keepAll: true,
+            reportDir: 'build/reports/tests/test',
+            reportFiles: 'index.html',
+            reportName: 'Test coverage'
+          ]
+
+          junit 'build/test-results/test/*.xml'
+        }
+      }
+    }
+
+    stage('Publish') {
+      steps {
+        timeout(10) {
+                input 'Keep going?'
+        }
+
+        withCredentials([usernamePassword(
+          credentialsId: 'repo.adeo.no',
+          usernameVariable: 'REPO_USERNAME',
+          passwordVariable: 'REPO_PASSWORD'
+        )]) {
+            sh "docker login -u ${REPO_USERNAME} -p ${REPO_PASSWORD} repo.adeo.no:5443"
+        }
+
+        script {
+          sh "./gradlew dockerPush"
+        }
+      }
+    }
+
+    stage("Publish service contract") {
+      steps {
+        withCredentials([usernamePassword(
+          credentialsId: 'repo.adeo.no',
+          usernameVariable: 'REPO_USERNAME',
+          passwordVariable: 'REPO_PASSWORD'
+        )]) {
+          sh "curl -vvv --user ${REPO_USERNAME}:${REPO_PASSWORD} --upload-file nais.yaml https://repo.adeo.no/repository/raw/nais/${APPLICATION_NAME}/${VERSION}/nais.yaml"
+        }
+      }
+    }
+
+    stage('Deploy to non-production') {
+      steps {
+        script {
+          response = naisDeploy.createNaisAutodeployment(env.APPLICATION_NAME, env.VERSION,"t0",env.ZONE ,env.NAMESPACE, "")
+        }
+      }
+    }
+
+    stage('Deploy to production') {
+      steps {
+        script {
+          response = naisDeploy.createNaisAutodeployment(env.APPLICATION_NAME, env.VERSION,"p", env.ZONE ,env.NAMESPACE, "")
+        }
+      }
+    }
+  }
+}

--- a/.service-template/LICENSE.md
+++ b/.service-template/LICENSE.md
@@ -1,0 +1,22 @@
+# The MIT License
+
+Copyright 2018 NAV (Arbeids- og velferdsdirektoratet) - The Norwegian Labour
+and Welfare Administration
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/.service-template/README.md
+++ b/.service-template/README.md
@@ -1,0 +1,20 @@
+# Dagpenger-SERVICENAME
+
+# Komme i gang
+
+Gradle brukes som byggverktøy og er bundlet inn.
+
+`./gradlew build`
+
+---
+
+# Henvendelser
+
+Spørsmål knyttet til koden eller prosjektet kan rettes mot:
+
+* André Roaldseth, andre.roaldseth@nav.no
+* Eller en annen måte for omverden å kontakte teamet på
+
+## For NAV-ansatte
+
+Interne henvendelser kan sendes via Slack i kanalen #dagpenger.

--- a/.service-template/build.gradle.kts
+++ b/.service-template/build.gradle.kts
@@ -1,0 +1,73 @@
+plugins {
+    id("application")
+    kotlin("jvm") version "1.2.51"
+    id("com.diffplug.gradle.spotless") version "3.13.0"
+    id("com.palantir.docker") version "0.20.1"
+    id("com.palantir.git-version") version "0.11.0"
+    id("com.adarshr.test-logger") version "1.5.0"
+}
+
+apply {
+    plugin("com.diffplug.gradle.spotless")
+    plugin("com.adarshr.test-logger")
+}
+
+repositories {
+    jcenter()
+    maven(url = "http://packages.confluent.io/maven/")
+    maven(url = "https://repo.adeo.no/repository/maven-releases/")
+}
+
+val gitVersion: groovy.lang.Closure<Any> by extra
+version = gitVersion()
+group = "no.nav.dagpenger"
+
+application {
+    applicationName = "dagpenger-SERVICENAME"
+    mainClassName = "no.nav.dagpenger.SERVICENAME"
+}
+
+docker {
+    name = "repo.adeo.no:5443/navikt/${application.applicationName}"
+    buildArgs(mapOf(
+        "APP_NAME" to application.applicationName,
+        "DIST_TAR" to "${application.applicationName}-${project.version}"
+    ))
+    files(tasks.findByName("distTar")?.outputs)
+    pull(true)
+    tags(project.version.toString())
+}
+
+val kotlinLoggingVersion = "1.4.9"
+val fuelVersion = "1.15.0"
+val confluentVersion = "4.1.2"
+val kafkaVersion = "2.0.0"
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("no.nav.dagpenger:streams:0.1.2")
+    implementation("no.nav.dagpenger:events:0.1.4")
+
+    implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
+    implementation("com.github.kittinunf.fuel:fuel:$fuelVersion")
+    implementation("com.github.kittinunf.fuel:fuel-gson:$fuelVersion")
+
+    compile("org.apache.kafka:kafka-clients:$kafkaVersion")
+    compile("org.apache.kafka:kafka-streams:$kafkaVersion")
+    compile("io.confluent:kafka-streams-avro-serde:$confluentVersion")
+
+    testImplementation(kotlin("test"))
+    testImplementation(kotlin("test-junit"))
+    testImplementation("junit:junit:4.12")
+    testImplementation("com.github.tomakehurst:wiremock:2.18.0")
+}
+
+spotless {
+    kotlin {
+        ktlint()
+    }
+    kotlinGradle {
+        target("*.gradle.kts", "additionalScripts/*.gradle.kts")
+        ktlint()
+    }
+}

--- a/.service-template/gradle.properties
+++ b/.service-template/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.caching=true
+org.gradle.parallel=true

--- a/.service-template/settings.gradle.kts
+++ b/.service-template/settings.gradle.kts
@@ -1,0 +1,9 @@
+rootProject.name = "dagpenger-SERVICENAME"
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        jcenter()
+        maven(url = "https://dl.bintray.com/gradle/gradle-plugins")
+    }
+}


### PR DESCRIPTION
To reduce drift between service we need to generate and maintain them in
a shared way where possible.

This is first just a simple template that can be used as a basis.

But we should look into tools that can continue to maintain and share
these files where desired after the initial setup