### PR TITLE
Add config enabling kustomize edit set image on NAIS application resources 

### DIFF
--- a/nais/bases/application-image.yaml
+++ b/nais/bases/application-image.yaml
@@ -1,0 +1,3 @@
+images:
+- kind: Application
+  path: spec/image

--- a/nais/bases/kustomization.yaml
+++ b/nais/bases/kustomization.yaml
@@ -29,3 +29,4 @@ vars:
 
 configurations:
   - variable-substition-alerts.yaml
+  - application-image.yaml

--- a/nais/java/kustomization.yaml
+++ b/nais/java/kustomization.yaml
@@ -1,6 +1,9 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../bases
+- ../bases
+images:
+- name: busybox
+  newName: alpine
+  newTag: "3.6"

--- a/nais/java/kustomization.yaml
+++ b/nais/java/kustomization.yaml
@@ -3,7 +3,4 @@ kind: Kustomization
 
 resources:
 - ../bases
-images:
-- name: busybox
-  newName: alpine
-  newTag: "3.6"
+


### PR DESCRIPTION
This PR makes it possible to use `kustomize edit set image ` on NAIS application resources.

See https://github.com/kubernetes-sigs/kustomize/blob/master/examples/image.md for examples. 